### PR TITLE
installation fix for wsl;gitignore updates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+build/
+PyEMEBSDDI_wrapper.egg-info/
+PyEMEBSDDI_wrapper/EMsoft_DIR.txt

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ Three ways to install PyEMEBSDDI_wrapper package (You need to provide the direct
 
 3. With downloaded package:
 
-`python3 setup.py --EMsoftBinDIR="abs/dir/to/EMsoft/Bin"`
+`python3 setup.py install --EMsoftBinDIR="abs/dir/to/EMsoft/Bin"`
 
 
 ## How to use?

--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 Three ways to install PyEMEBSDDI_wrapper package:
 With downloaded package:
-(1) python3 setup.py --EMsoftBinDIR="abs/dir/to/EMsoft/Bin"
+(1) python3 setup.py install --EMsoftBinDIR="abs/dir/to/EMsoft/Bin"
 (2) pip install . --install-option="--EMsoftBinDIR=abs/dir/to/EMsoft/Bin"
 Without downloaded package:
 (3) pip install PyEMEBSDDI_wrapper --install-option="--EMsoftBinDIR=abs/dir/to/EMsoft/Bin"


### PR DESCRIPTION
Readme.md->README.md so that line 99 in setup.py can correctly join the filename 

missing the 'install' for the installation instruction: python3 setup.py install --EMsoftBinDIR="abs/dir/to/EMsoft/Bin"